### PR TITLE
Allow build-firmware to work with ccache in lib64

### DIFF
--- a/build-firmware.sh
+++ b/build-firmware.sh
@@ -275,7 +275,7 @@ locate_tools() {
       exit
     fi
   done
-  if [ "$FOUND_PATH" != "/usr/lib/ccache" ]; then
+  if ! ( [ "$FOUND_PATH" == "/usr/lib/ccache" ] || [ "$FOUND_PATH" == "/usr/lib64/ccache" ] ); then
      eval "$DEST_VAR=$FOUND_PATH/"
   fi
 }


### PR DESCRIPTION


### Description
In Fedora, at least, ccache lives in `/usr/lib64/` rather than `/usr/lib`. Check both.

### Benefits
Allow the build-firmware script to work when ccache is hoarding in `/usr/lib64/ccache` in addition to `/usr/lib/ccache`

