### PR TITLE
Unwrap `screen.h` sub-headers

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_ABOUT_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_ABOUT_SCREEN
 #define FTDI_ABOUT_SCREEN_CLASS AboutScreen
 
@@ -30,5 +31,3 @@ class AboutScreen : public BaseScreen, public UncachedScreen {
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_ABOUT_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_ADVANCED_SETTINGS_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_ADVANCED_SETTINGS_MENU
 #define FTDI_ADVANCED_SETTINGS_MENU_CLASS AdvancedSettingsMenu
 
@@ -29,5 +30,3 @@ class AdvancedSettingsMenu : public BaseScreen, public CachedScreen<ADVANCED_SET
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_ADVANCED_SETTINGS_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/alert_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/alert_dialog_box.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_ALERT_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_ALERT_DIALOG_BOX
 #define FTDI_ALERT_DIALOG_BOX_CLASS AlertDialogBox
 
@@ -36,5 +37,3 @@ class AlertDialogBox : public DialogBoxBaseClass, public CachedScreen<ALERT_BOX_
     template<typename T> static void showError(T);
     static void hide();
 };
-
-#endif // FTDI_ALERT_DIALOG_BOX

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/backlash_compensation_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/backlash_compensation_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BACKLASH_COMP_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_BACKLASH_COMP_SCREEN
 #define FTDI_BACKLASH_COMP_SCREEN_CLASS BacklashCompensationScreen
 
-  class BacklashCompensationScreen : public BaseNumericAdjustmentScreen, public CachedScreen<BACKLASH_COMPENSATION_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_BACKLASH_COMP_SCREEN
+class BacklashCompensationScreen : public BaseNumericAdjustmentScreen, public CachedScreen<BACKLASH_COMPENSATION_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_numeric_adjustment_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_numeric_adjustment_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BASE_NUMERIC_ADJ_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_BASE_NUMERIC_ADJ_SCREEN
 #define FTDI_BASE_NUMERIC_ADJ_SCREEN_CLASS BaseNumericAdjustmentScreen
 
@@ -84,5 +85,3 @@ class BaseNumericAdjustmentScreen : public BaseScreen {
     static void onEntry();
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_BASE_NUMERIC_ADJ_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BASE_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_BASE_SCREEN
 #define FTDI_BASE_SCREEN_CLASS BaseScreen
 
@@ -40,5 +41,3 @@ class BaseScreen : public UIScreen {
     static void onEntry();
     static void onIdle();
 };
-
-#endif // FTDI_BASE_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.h
@@ -19,45 +19,44 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BED_MESH_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_BED_MESH_SCREEN
 #define FTDI_BED_MESH_SCREEN_CLASS BedMeshScreen
 
-  struct BedMeshScreenData {
-    enum : uint8_t {
-      MSG_NONE,
-      MSG_MESH_COMPLETE,
-      MSG_MESH_INCOMPLETE
-    } message;
-    uint8_t count;
-    uint8_t highlightedTag;
-  };
+struct BedMeshScreenData {
+  enum : uint8_t {
+    MSG_NONE,
+    MSG_MESH_COMPLETE,
+    MSG_MESH_INCOMPLETE
+  } message;
+  uint8_t count;
+  uint8_t highlightedTag;
+};
 
-  class BedMeshScreen : public BaseScreen, public CachedScreen<BED_MESH_SCREEN_CACHE> {
-    private:
-      enum MeshOpts {
-        USE_POINTS    = 0x01,
-        USE_COLORS    = 0x02,
-        USE_TAGS      = 0x04,
-        USE_HIGHLIGHT = 0x08,
-        USE_AUTOSCALE = 0x10
-      };
+class BedMeshScreen : public BaseScreen, public CachedScreen<BED_MESH_SCREEN_CACHE> {
+  private:
+    enum MeshOpts {
+      USE_POINTS    = 0x01,
+      USE_COLORS    = 0x02,
+      USE_TAGS      = 0x04,
+      USE_HIGHLIGHT = 0x08,
+      USE_AUTOSCALE = 0x10
+    };
 
-      static uint8_t pointToTag(uint8_t x, uint8_t y);
-      static bool tagToPoint(uint8_t tag, uint8_t &x, uint8_t &y);
-      static float getHightlightedValue();
-      static void drawHighlightedPointValue();
-      static void drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max = 0.1);
+    static uint8_t pointToTag(uint8_t x, uint8_t y);
+    static bool tagToPoint(uint8_t tag, uint8_t &x, uint8_t &y);
+    static float getHightlightedValue();
+    static void drawHighlightedPointValue();
+    static void drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max = 0.1);
 
-    public:
-      static void onMeshUpdate(const int8_t x, const int8_t y, const float val);
-      static void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t);
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchStart(uint8_t tag);
-      static bool onTouchEnd(uint8_t tag);
+  public:
+    static void onMeshUpdate(const int8_t x, const int8_t y, const float val);
+    static void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t);
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchStart(uint8_t tag);
+    static bool onTouchEnd(uint8_t tag);
 
-      static void startMeshProbe();
-  };
-
-#endif // FTDI_BED_MESH_SCREEN
+    static void startMeshProbe();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_advanced_settings.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_advanced_settings.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BIO_ADVANCED_SETTINGS_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_BIO_ADVANCED_SETTINGS_MENU
 #define FTDI_BIO_ADVANCED_SETTINGS_MENU_CLASS AdvancedSettingsMenu
 
@@ -29,5 +30,3 @@ class AdvancedSettingsMenu : public BaseScreen, public CachedScreen<ADVANCED_SET
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_BIO_ADVANCED_SETTINGS_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_confirm_home_e.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_confirm_home_e.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BIO_CONFIRM_HOME_E // Don't use pragma once here
+#pragma once
+
 #define FTDI_BIO_CONFIRM_HOME_E
 #define FTDI_BIO_CONFIRM_HOME_E_CLASS BioConfirmHomeE
 
-  class BioConfirmHomeE : public DialogBoxBaseClass, public UncachedScreen {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_BIO_CONFIRM_HOME_E
+class BioConfirmHomeE : public DialogBoxBaseClass, public UncachedScreen {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_confirm_home_xyz.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_confirm_home_xyz.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BIO_CONFIRM_HOME_XYZ // Don't use pragma once here
+#pragma once
+
 #define FTDI_BIO_CONFIRM_HOME_XYZ
 #define FTDI_BIO_CONFIRM_HOME_XYZ_CLASS BioConfirmHomeXYZ
 
-  class BioConfirmHomeXYZ : public DialogBoxBaseClass, public UncachedScreen {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_BIO_CONFIRM_HOME_XYZ
+class BioConfirmHomeXYZ : public DialogBoxBaseClass, public UncachedScreen {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_main_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_main_menu.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BIO_MAIN_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_BIO_MAIN_MENU
 #define FTDI_BIO_MAIN_MENU_CLASS MainMenu
 
@@ -29,5 +30,3 @@ class MainMenu : public BaseScreen, public CachedScreen<MENU_SCREEN_CACHE> {
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_BIO_MAIN_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_printing_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_printing_dialog_box.h
@@ -20,26 +20,25 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BIO_PRINTING_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_BIO_PRINTING_DIALOG_BOX
 #define FTDI_BIO_PRINTING_DIALOG_BOX_CLASS BioPrintingDialogBox
 
-  class BioPrintingDialogBox : public BaseScreen, public CachedScreen<PRINTING_SCREEN_CACHE,PRINTING_SCREEN_DL_SIZE> {
-    private:
-      static void draw_status_message(draw_mode_t, const char * const);
-      static void draw_progress(draw_mode_t);
-      static void draw_time_remaining(draw_mode_t);
-      static void draw_interaction_buttons(draw_mode_t);
-    public:
-      static void onRedraw(draw_mode_t);
+class BioPrintingDialogBox : public BaseScreen, public CachedScreen<PRINTING_SCREEN_CACHE,PRINTING_SCREEN_DL_SIZE> {
+  private:
+    static void draw_status_message(draw_mode_t, const char * const);
+    static void draw_progress(draw_mode_t);
+    static void draw_time_remaining(draw_mode_t);
+    static void draw_interaction_buttons(draw_mode_t);
+  public:
+    static void onRedraw(draw_mode_t);
 
-      static void show();
+    static void show();
 
-      static void setStatusMessage(const char *);
-      static void setStatusMessage(progmem_str);
+    static void setStatusMessage(const char *);
+    static void setStatusMessage(progmem_str);
 
-      static void onIdle();
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_BIO_PRINTING_DIALOG_BOX
+    static void onIdle();
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_status_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_status_screen.h
@@ -21,37 +21,36 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BIO_STATUS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_BIO_STATUS_SCREEN
 #define FTDI_BIO_STATUS_SCREEN_CLASS StatusScreen
 
-  class StatusScreen : public BaseScreen, public CachedScreen<STATUS_SCREEN_CACHE> {
-    private:
-      static float increment;
-      static bool  jog_xy;
-      static bool  fine_motion;
+class StatusScreen : public BaseScreen, public CachedScreen<STATUS_SCREEN_CACHE> {
+  private:
+    static float increment;
+    static bool  jog_xy;
+    static bool  fine_motion;
 
-      static void draw_progress(draw_mode_t what);
-      static void draw_temperature(draw_mode_t what);
-      static void draw_syringe(draw_mode_t what);
-      static void draw_arrows(draw_mode_t what);
-      static void draw_overlay_icons(draw_mode_t what);
-      static void draw_fine_motion(draw_mode_t what);
-      static void draw_buttons(draw_mode_t what);
-    public:
-      static void loadBitmaps();
-      static void unlockMotors();
+    static void draw_progress(draw_mode_t what);
+    static void draw_temperature(draw_mode_t what);
+    static void draw_syringe(draw_mode_t what);
+    static void draw_arrows(draw_mode_t what);
+    static void draw_overlay_icons(draw_mode_t what);
+    static void draw_fine_motion(draw_mode_t what);
+    static void draw_buttons(draw_mode_t what);
+  public:
+    static void loadBitmaps();
+    static void unlockMotors();
 
-      static void setStatusMessage(const char *);
-      static void setStatusMessage(progmem_str);
+    static void setStatusMessage(const char *);
+    static void setStatusMessage(progmem_str);
 
-      static void onRedraw(draw_mode_t);
+    static void onRedraw(draw_mode_t);
 
-      static bool onTouchStart(uint8_t tag);
-      static bool onTouchHeld(uint8_t tag);
-      static bool onTouchEnd(uint8_t tag);
-      static void onIdle();
+    static bool onTouchStart(uint8_t tag);
+    static bool onTouchHeld(uint8_t tag);
+    static bool onTouchEnd(uint8_t tag);
+    static void onIdle();
 
-  };
-
-#endif // FTDI_BIO_STATUS_SCREEN
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_tune_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_tune_menu.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BIO_TUNE_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_BIO_TUNE_MENU
 #define FTDI_BIO_TUNE_MENU_CLASS TuneMenu
 
@@ -32,5 +33,3 @@ class TuneMenu : public BaseScreen, public CachedScreen<TUNE_SCREEN_CACHE> {
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_BIO_TUNE_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/boot_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/boot_screen.h
@@ -21,7 +21,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_BOOT_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_BOOT_SCREEN
 #define FTDI_BOOT_SCREEN_CLASS BootScreen
 
@@ -32,5 +33,3 @@ class BootScreen : public BaseScreen, public UncachedScreen {
     static void onRedraw(draw_mode_t);
     static void onIdle();
 };
-
-#endif // FTDI_BOOT_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/case_light_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/case_light_screen.h
@@ -19,14 +19,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_CASE_LIGHT_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_CASE_LIGHT_SCREEN
 #define FTDI_CASE_LIGHT_SCREEN_CLASS CaseLightScreen
 
-  class CaseLightScreen : public BaseNumericAdjustmentScreen, public CachedScreen<CASE_LIGHT_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_CASE_LIGHT_SCREEN
+class CaseLightScreen : public BaseNumericAdjustmentScreen, public CachedScreen<CASE_LIGHT_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/change_filament_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/change_filament_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_CHANGE_FILAMENT_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_CHANGE_FILAMENT_SCREEN
 #define FTDI_CHANGE_FILAMENT_SCREEN_CLASS ChangeFilamentScreen
 
@@ -48,5 +49,3 @@ class ChangeFilamentScreen : public BaseScreen, public CachedScreen<CHANGE_FILAM
     static bool onTouchHeld(uint8_t tag);
     static void onIdle();
 };
-
-#endif // FTDI_ADVANCED_SETTINGS_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_advanced_settings_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_advanced_settings_menu.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_ADVANCED_SETTINGS_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_ADVANCED_SETTINGS_MENU
 #define FTDI_COCOA_ADVANCED_SETTINGS_MENU_CLASS AdvancedSettingsMenu
 
@@ -29,5 +30,3 @@ class AdvancedSettingsMenu : public BaseScreen, public CachedScreen<ADVANCED_SET
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_COCOA_ADVANCED_SETTINGS_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_load_chocolate.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_load_chocolate.h
@@ -21,15 +21,14 @@
  *   location: <https://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_LOAD_CHOCOLATE_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_LOAD_CHOCOLATE_SCREEN
 #define FTDI_COCOA_LOAD_CHOCOLATE_SCREEN_CLASS LoadChocolateScreen
 
-  class LoadChocolateScreen : public BaseScreen, public CachedScreen<LOAD_CHOCOLATE_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_COCOA_LOAD_CHOCOLATE_SCREEN
+class LoadChocolateScreen : public BaseScreen, public CachedScreen<LOAD_CHOCOLATE_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_main_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_main_menu.h
@@ -21,7 +21,8 @@
  *   location: <https://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_MAIN_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_MAIN_MENU
 #define FTDI_COCOA_MAIN_MENU_CLASS MainMenu
 
@@ -30,5 +31,3 @@ class MainMenu : public BaseScreen, public CachedScreen<MENU_SCREEN_CACHE> {
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_COCOA_MAIN_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_move_e_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_move_e_screen.h
@@ -21,14 +21,13 @@
  *   location: <https://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_MOVE_E_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_MOVE_E_SCREEN
 #define FTDI_COCOA_MOVE_E_SCREEN_CLASS MoveEScreen
 
-  class MoveEScreen : public BaseMoveAxisScreen, public CachedScreen<MOVE_E_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static void onIdle();
-  };
-
-#endif // FTDI_COCOA_MOVE_E_SCREEN
+class MoveEScreen : public BaseMoveAxisScreen, public CachedScreen<MOVE_E_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_move_xyz_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_move_xyz_screen.h
@@ -21,14 +21,13 @@
  *   location: <https://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_MOVE_XYZ_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_MOVE_XYZ_SCREEN
 #define FTDI_COCOA_MOVE_XYZ_SCREEN_CLASS MoveXYZScreen
 
-  class MoveXYZScreen : public BaseMoveAxisScreen, public CachedScreen<MOVE_XYZ_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static void onIdle();
-  };
-
-#endif // FTDI_COCOA_MOVE_XYZ_SCREEN
+class MoveXYZScreen : public BaseMoveAxisScreen, public CachedScreen<MOVE_XYZ_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_preheat_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_preheat_menu.h
@@ -19,14 +19,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_PREHEAT_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_PREHEAT_MENU
 #define FTDI_COCOA_PREHEAT_MENU_CLASS PreheatMenu
 
-  class PreheatMenu : public BaseScreen, public CachedScreen<PREHEAT_MENU_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_COCOA_PREHEAT_MENU
+class PreheatMenu : public BaseScreen, public CachedScreen<PREHEAT_MENU_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_preheat_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_preheat_screen.h
@@ -19,29 +19,28 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_PREHEAT_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_PREHEAT_SCREEN
 #define FTDI_COCOA_PREHEAT_SCREEN_CLASS PreheatTimerScreen
 
-  struct PreheatTimerScreenData {
-      uint32_t start_ms;
-  };
+struct PreheatTimerScreenData {
+    uint32_t start_ms;
+};
 
-  class PreheatTimerScreen : public BaseScreen, public CachedScreen<PREHEAT_TIMER_SCREEN_CACHE> {
-    private:
-      static uint16_t secondsRemaining();
+class PreheatTimerScreen : public BaseScreen, public CachedScreen<PREHEAT_TIMER_SCREEN_CACHE> {
+  private:
+    static uint16_t secondsRemaining();
 
-      static void draw_message(draw_mode_t);
-      static void draw_time_remaining(draw_mode_t);
-      static void draw_interaction_buttons(draw_mode_t);
-      static void draw_adjuster(draw_mode_t, uint8_t tag, progmem_str label, float value, int16_t x, int16_t y, int16_t w, int16_t h);
-    public:
-      static void onRedraw(draw_mode_t);
+    static void draw_message(draw_mode_t);
+    static void draw_time_remaining(draw_mode_t);
+    static void draw_interaction_buttons(draw_mode_t);
+    static void draw_adjuster(draw_mode_t, uint8_t tag, progmem_str label, float value, int16_t x, int16_t y, int16_t w, int16_t h);
+  public:
+    static void onRedraw(draw_mode_t);
 
-      static void onEntry();
-      static void onIdle();
-      static bool onTouchHeld(uint8_t tag);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_COCOA_PREHEAT_SCREEN
+    static void onEntry();
+    static void onIdle();
+    static bool onTouchHeld(uint8_t tag);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_status_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_status_screen.h
@@ -21,37 +21,35 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_STATUS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_STATUS_SCREEN
 #define FTDI_COCOA_STATUS_SCREEN_CLASS StatusScreen
 
-  class StatusScreen : public BaseScreen, public CachedScreen<STATUS_SCREEN_CACHE> {
-    private:
-      static float increment;
-      static bool  jog_xy;
-      static bool  fine_motion;
+class StatusScreen : public BaseScreen, public CachedScreen<STATUS_SCREEN_CACHE> {
+  private:
+    static float increment;
+    static bool  jog_xy;
+    static bool  fine_motion;
 
-      static void draw_progress(draw_mode_t what);
-      static void draw_temperature(draw_mode_t what);
-      static void draw_syringe(draw_mode_t what);
-      static void draw_arrows(draw_mode_t what);
-      static void draw_overlay_icons(draw_mode_t what);
-      static void draw_fine_motion(draw_mode_t what);
-      static void draw_buttons(draw_mode_t what);
-    public:
-      static void loadBitmaps();
-      static void unlockMotors();
+    static void draw_progress(draw_mode_t what);
+    static void draw_temperature(draw_mode_t what);
+    static void draw_syringe(draw_mode_t what);
+    static void draw_arrows(draw_mode_t what);
+    static void draw_overlay_icons(draw_mode_t what);
+    static void draw_fine_motion(draw_mode_t what);
+    static void draw_buttons(draw_mode_t what);
+  public:
+    static void loadBitmaps();
+    static void unlockMotors();
 
-      static void setStatusMessage(const char *);
-      static void setStatusMessage(progmem_str);
+    static void setStatusMessage(const char *);
+    static void setStatusMessage(progmem_str);
 
-      static void onRedraw(draw_mode_t);
+    static void onRedraw(draw_mode_t);
 
-      static bool onTouchStart(uint8_t tag);
-      static bool onTouchHeld(uint8_t tag);
-      static bool onTouchEnd(uint8_t tag);
-      static void onIdle();
-
-  };
-
-#endif // FTDI_COCOA_STATUS_SCREEN
+    static bool onTouchStart(uint8_t tag);
+    static bool onTouchHeld(uint8_t tag);
+    static bool onTouchEnd(uint8_t tag);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_unload_cartridge.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/cocoa_press_unload_cartridge.h
@@ -21,15 +21,14 @@
  *   location: <https://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#ifndef FTDI_COCOA_UNLOAD_CARTRIDGE_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_COCOA_UNLOAD_CARTRIDGE_SCREEN
 #define FTDI_COCOA_UNLOAD_CARTRIDGE_SCREEN_CLASS UnloadCartridgeScreen
 
-  class UnloadCartridgeScreen : public BaseScreen, public CachedScreen<UNLOAD_CARTRIDGE_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_COCOA_UNLOAD_CARTRIDGE_SCREEN
+class UnloadCartridgeScreen : public BaseScreen, public CachedScreen<UNLOAD_CARTRIDGE_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_abort_print_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_abort_print_dialog_box.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_CONFIRM_ABORT_PRINT_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_CONFIRM_ABORT_PRINT_DIALOG_BOX
 #define FTDI_CONFIRM_ABORT_PRINT_DIALOG_BOX_CLASS ConfirmAbortPrintDialogBox
 
@@ -29,5 +30,3 @@ class ConfirmAbortPrintDialogBox : public DialogBoxBaseClass, public UncachedScr
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_CONFIRM_ABORT_PRINT_DIALOG_BOX

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_auto_calibration_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_auto_calibration_dialog_box.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_CONFIRM_AUTO_CALIBRATION_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_CONFIRM_AUTO_CALIBRATION_DIALOG_BOX
 #define FTDI_CONFIRM_AUTO_CALIBRATION_DIALOG_BOX_CLASS ConfirmAutoCalibrationDialogBox
 
@@ -29,5 +30,3 @@ class ConfirmAutoCalibrationDialogBox : public DialogBoxBaseClass, public Uncach
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_CONFIRM_AUTO_CALIBRATION_DIALOG_BOX

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_erase_flash_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_erase_flash_dialog_box.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_CONFIRM_ERASE_FLASH_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_CONFIRM_ERASE_FLASH_DIALOG_BOX
 #define FTDI_CONFIRM_ERASE_FLASH_DIALOG_BOX_CLASS ConfirmEraseFlashDialogBox
 
-  class ConfirmEraseFlashDialogBox : public DialogBoxBaseClass, public UncachedScreen {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_CONFIRM_ERASE_FLASH_DIALOG_BOX
+class ConfirmEraseFlashDialogBox : public DialogBoxBaseClass, public UncachedScreen {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_start_print_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_start_print_dialog_box.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_CONFIRM_START_PRINT_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_CONFIRM_START_PRINT_DIALOG_BOX
 #define FTDI_CONFIRM_START_PRINT_DIALOG_BOX_CLASS ConfirmStartPrintDialogBox
 
@@ -40,5 +41,3 @@ class ConfirmStartPrintDialogBox : public DialogBoxBaseClass, public UncachedScr
 
     static void show(uint8_t file_index);
 };
-
-#endif // FTDI_CONFIRM_START_PRINT_DIALOG_BOX

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_user_request_alert_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_user_request_alert_box.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_CONFIRM_USER_REQUEST_ALERT_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_CONFIRM_USER_REQUEST_ALERT_BOX
 #define FTDI_CONFIRM_USER_REQUEST_ALERT_BOX_CLASS ConfirmUserRequestAlertBox
 
@@ -32,5 +33,3 @@ class ConfirmUserRequestAlertBox : public AlertDialogBox {
     static void show(const char*);
     static void onIdle();
 };
-
-#endif // FTDI_CONFIRM_USER_REQUEST_ALERT_BOX

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/custom_user_menus.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/custom_user_menus.h
@@ -20,14 +20,13 @@
  *
  */
 
-#ifndef FTDI_CUSTOM_USER_MENUS // Don't use pragma once here
+#pragma once
+
 #define FTDI_CUSTOM_USER_MENUS
 #define FTDI_CUSTOM_USER_MENUS_CLASS CustomUserMenus
 
-  class CustomUserMenus : public BaseScreen, public CachedScreen<CUSTOM_USER_MENUS_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_CUSTOM_USER_MENUS
+class CustomUserMenus : public BaseScreen, public CachedScreen<CUSTOM_USER_MENUS_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/default_acceleration_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/default_acceleration_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_DEFAULT_ACCELERATION_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_DEFAULT_ACCELERATION_SCREEN
 #define FTDI_DEFAULT_ACCELERATION_SCREEN_CLASS DefaultAccelerationScreen
 
-  class DefaultAccelerationScreen : public BaseNumericAdjustmentScreen, public CachedScreen<DEFAULT_ACCELERATION_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_DEFAULT_ACCELERATION_SCREEN
+class DefaultAccelerationScreen : public BaseNumericAdjustmentScreen, public CachedScreen<DEFAULT_ACCELERATION_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/developer_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/developer_menu.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_DEVELOPER_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_DEVELOPER_MENU
 #define FTDI_DEVELOPER_MENU_CLASS DeveloperMenu
 
-  class DeveloperMenu : public BaseScreen, public UncachedScreen {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_DEVELOPER_MENU
+class DeveloperMenu : public BaseScreen, public UncachedScreen {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/dialog_box_base_class.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/dialog_box_base_class.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_DIALOG_BOX_BASE_CLASS // Don't use pragma once here
+#pragma once
+
 #define FTDI_DIALOG_BOX_BASE_CLASS
 #define FTDI_DIALOG_BOX_BASE_CLASS_CLASS DialogBoxBaseClass
 
@@ -37,5 +38,3 @@ class DialogBoxBaseClass : public BaseScreen {
     static bool onTouchEnd(uint8_t tag);
     static void onIdle();
 };
-
-#endif // FTDI_DIALOG_BOX_BASE_CLASS

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/display_tuning_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/display_tuning_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_DISPLAY_TUNING_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_DISPLAY_TUNING_SCREEN
 #define FTDI_DISPLAY_TUNING_SCREEN_CLASS DisplayTuningScreen
 
-  class DisplayTuningScreen : public BaseNumericAdjustmentScreen, public CachedScreen<DISPLAY_TIMINGS_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_DISPLAY_TUNING_SCREEN
+class DisplayTuningScreen : public BaseNumericAdjustmentScreen, public CachedScreen<DISPLAY_TIMINGS_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/endstop_state_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/endstop_state_screen.h
@@ -20,17 +20,16 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_ENDSTOP_STATE_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_ENDSTOP_STATE_SCREEN
 #define FTDI_ENDSTOP_STATE_SCREEN_CLASS EndstopStatesScreen
 
-  class EndstopStatesScreen : public BaseScreen, public UncachedScreen {
-    public:
-      static void onEntry();
-      static void onExit();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-      static void onIdle();
-  };
-
-#endif // FTDI_ENDSTOP_STATE_SCREEN
+class EndstopStatesScreen : public BaseScreen, public UncachedScreen {
+  public:
+    static void onEntry();
+    static void onExit();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/feedrate_percent_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/feedrate_percent_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_FEEDRATE_PERCENT_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_FEEDRATE_PERCENT_SCREEN
 #define FTDI_FEEDRATE_PERCENT_SCREEN_CLASS FeedratePercentScreen
 
-  class FeedratePercentScreen : public BaseNumericAdjustmentScreen, public CachedScreen<MAX_FEEDRATE_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_FEEDRATE_PERCENT_SCREEN
+class FeedratePercentScreen : public BaseNumericAdjustmentScreen, public CachedScreen<MAX_FEEDRATE_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_menu.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_FILAMENT_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_FILAMENT_MENU
 #define FTDI_FILAMENT_MENU_CLASS FilamentMenu
 
-  class FilamentMenu : public BaseNumericAdjustmentScreen, public CachedScreen<FILAMENT_MENU_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_FILAMENT_MENU
+class FilamentMenu : public BaseNumericAdjustmentScreen, public CachedScreen<FILAMENT_MENU_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_runout_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_runout_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_FILAMENT_RUNOUT_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_FILAMENT_RUNOUT_SCREEN
 #define FTDI_FILAMENT_RUNOUT_SCREEN_CLASS FilamentRunoutScreen
 
-  class FilamentRunoutScreen : public BaseNumericAdjustmentScreen, public CachedScreen<FILAMENT_RUNOUT_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_FILAMENT_RUNOUT_SCREEN
+class FilamentRunoutScreen : public BaseNumericAdjustmentScreen, public CachedScreen<FILAMENT_RUNOUT_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/files_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/files_screen.h
@@ -20,57 +20,56 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_FILES_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_FILES_SCREEN
 #define FTDI_FILES_SCREEN_CLASS FilesScreen
 
-  struct FilesScreenData {
-    struct {
-      uint8_t is_dir  : 1;
-      uint8_t is_root : 1;
-    } flags;
-    uint8_t   selected_tag;
-    uint8_t   num_page;
-    uint8_t   cur_page;
-    #if ENABLED(SCROLL_LONG_FILENAMES) && (FTDI_API_LEVEL >= 810)
-      uint16_t  scroll_pos;
-      uint16_t  scroll_max;
+struct FilesScreenData {
+  struct {
+    uint8_t is_dir  : 1;
+    uint8_t is_root : 1;
+  } flags;
+  uint8_t   selected_tag;
+  uint8_t   num_page;
+  uint8_t   cur_page;
+  #if ENABLED(SCROLL_LONG_FILENAMES) && (FTDI_API_LEVEL >= 810)
+    uint16_t  scroll_pos;
+    uint16_t  scroll_max;
+  #endif
+};
+
+class FilesScreen : public BaseScreen, public CachedScreen<FILES_SCREEN_CACHE, FILE_SCREEN_DL_SIZE> {
+  private:
+    #if ENABLED(TOUCH_UI_PORTRAIT)
+      static constexpr uint8_t header_h       = 2;
+      static constexpr uint8_t footer_h       = 2;
+      static constexpr uint8_t files_per_page = 11;
+    #else
+      static constexpr uint8_t header_h       = 1;
+      static constexpr uint8_t footer_h       = 1;
+      static constexpr uint8_t files_per_page = 6;
     #endif
-  };
 
-  class FilesScreen : public BaseScreen, public CachedScreen<FILES_SCREEN_CACHE, FILE_SCREEN_DL_SIZE> {
-    private:
-      #if ENABLED(TOUCH_UI_PORTRAIT)
-        static constexpr uint8_t header_h       = 2;
-        static constexpr uint8_t footer_h       = 2;
-        static constexpr uint8_t files_per_page = 11;
-      #else
-        static constexpr uint8_t header_h       = 1;
-        static constexpr uint8_t footer_h       = 1;
-        static constexpr uint8_t files_per_page = 6;
-      #endif
+    static uint8_t  getTagForLine(uint8_t line) {return line + 2;}
+    static uint8_t  getLineForTag(uint8_t tag)  {return  tag - 2;}
+    static uint16_t getFileForTag(uint8_t tag);
+    static uint16_t getSelectedFileIndex();
 
-      static uint8_t  getTagForLine(uint8_t line) {return line + 2;}
-      static uint8_t  getLineForTag(uint8_t tag)  {return  tag - 2;}
-      static uint16_t getFileForTag(uint8_t tag);
-      static uint16_t getSelectedFileIndex();
+    inline static const char *getSelectedShortFilename() {return getSelectedFilename(false);}
+    inline static const char *getSelectedLongFilename()  {return getSelectedFilename(true);}
+    static const char *getSelectedFilename(bool longName);
 
-      inline static const char *getSelectedShortFilename() {return getSelectedFilename(false);}
-      inline static const char *getSelectedLongFilename()  {return getSelectedFilename(true);}
-      static const char *getSelectedFilename(bool longName);
+    static void drawFileButton(const char* filename, uint8_t tag, bool is_dir, bool is_highlighted);
+    static void drawFileList();
+    static void drawHeader();
+    static void drawFooter();
+    static void drawSelectedFile();
 
-      static void drawFileButton(const char* filename, uint8_t tag, bool is_dir, bool is_highlighted);
-      static void drawFileList();
-      static void drawHeader();
-      static void drawFooter();
-      static void drawSelectedFile();
-
-      static void gotoPage(uint8_t);
-    public:
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-      static void onIdle();
-  };
-
-#endif // FTDI_FILES_SCREEN
+    static void gotoPage(uint8_t);
+  public:
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.h
@@ -20,49 +20,48 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_INTERFACE_SETTINGS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_INTERFACE_SETTINGS_SCREEN
 #define FTDI_INTERFACE_SETTINGS_SCREEN_CLASS InterfaceSettingsScreen
 
-  struct InterfaceSettingsScreenData {
-    uint8_t volume;
-    uint8_t brightness;
-  };
+struct InterfaceSettingsScreenData {
+  uint8_t volume;
+  uint8_t brightness;
+};
 
-  class InterfaceSettingsScreen : public BaseScreen, public CachedScreen<INTERFACE_SETTINGS_SCREEN_CACHE> {
-    private:
-      struct persistent_data_t {
-        uint32_t touch_transform_a;
-        uint32_t touch_transform_b;
-        uint32_t touch_transform_c;
-        uint32_t touch_transform_d;
-        uint32_t touch_transform_e;
-        uint32_t touch_transform_f;
-        uint16_t passcode;
-        uint8_t  display_brightness;
-        int8_t   display_h_offset_adj;
-        int8_t   display_v_offset_adj;
-        uint8_t  sound_volume;
-        uint8_t  bit_flags;
-        uint8_t  event_sounds[InterfaceSoundsScreen::NUM_EVENTS];
-      };
+class InterfaceSettingsScreen : public BaseScreen, public CachedScreen<INTERFACE_SETTINGS_SCREEN_CACHE> {
+  private:
+    struct persistent_data_t {
+      uint32_t touch_transform_a;
+      uint32_t touch_transform_b;
+      uint32_t touch_transform_c;
+      uint32_t touch_transform_d;
+      uint32_t touch_transform_e;
+      uint32_t touch_transform_f;
+      uint16_t passcode;
+      uint8_t  display_brightness;
+      int8_t   display_h_offset_adj;
+      int8_t   display_v_offset_adj;
+      uint8_t  sound_volume;
+      uint8_t  bit_flags;
+      uint8_t  event_sounds[InterfaceSoundsScreen::NUM_EVENTS];
+    };
 
-    public:
-      #ifdef ARCHIM2_SPI_FLASH_EEPROM_BACKUP_SIZE
-        static bool backupEEPROM();
-      #endif
+  public:
+    #ifdef ARCHIM2_SPI_FLASH_EEPROM_BACKUP_SIZE
+      static bool backupEEPROM();
+    #endif
 
-      static void saveSettings(char *);
-      static void loadSettings(const char *);
-      static void defaultSettings();
-      static void failSafeSettings();
+    static void saveSettings(char *);
+    static void loadSettings(const char *);
+    static void defaultSettings();
+    static void failSafeSettings();
 
-      static void onStartup();
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchStart(uint8_t tag);
-      static bool onTouchEnd(uint8_t tag);
-      static void onIdle();
-  };
-
-#endif // FTDI_INTERFACE_SETTINGS_SCREEN
+    static void onStartup();
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchStart(uint8_t tag);
+    static bool onTouchEnd(uint8_t tag);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_sounds_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_sounds_screen.h
@@ -20,39 +20,38 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_INTERFACE_SOUNDS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_INTERFACE_SOUNDS_SCREEN
 #define FTDI_INTERFACE_SOUNDS_SCREEN_CLASS InterfaceSoundsScreen
 
-  class InterfaceSoundsScreen : public BaseScreen, public CachedScreen<INTERFACE_SOUNDS_SCREEN_CACHE> {
-    public:
-      enum event_t {
-        PRINTING_STARTED  = 0,
-        PRINTING_FINISHED = 1,
-        PRINTING_FAILED   = 2,
+class InterfaceSoundsScreen : public BaseScreen, public CachedScreen<INTERFACE_SOUNDS_SCREEN_CACHE> {
+  public:
+    enum event_t {
+      PRINTING_STARTED  = 0,
+      PRINTING_FINISHED = 1,
+      PRINTING_FAILED   = 2,
 
-        NUM_EVENTS
-      };
+      NUM_EVENTS
+    };
 
-    private:
-      friend class InterfaceSettingsScreen;
+  private:
+    friend class InterfaceSettingsScreen;
 
-      static uint8_t event_sounds[NUM_EVENTS];
+    static uint8_t event_sounds[NUM_EVENTS];
 
-      static const char* getSoundSelection(event_t);
-      static void toggleSoundSelection(event_t);
-      static void setSoundSelection(event_t, const FTDI::SoundPlayer::sound_t*);
+    static const char* getSoundSelection(event_t);
+    static void toggleSoundSelection(event_t);
+    static void setSoundSelection(event_t, const FTDI::SoundPlayer::sound_t*);
 
-    public:
-      static void playEventSound(event_t, FTDI::play_mode_t = FTDI::PLAY_ASYNCHRONOUS);
+  public:
+    static void playEventSound(event_t, FTDI::play_mode_t = FTDI::PLAY_ASYNCHRONOUS);
 
-      static void defaultSettings();
+    static void defaultSettings();
 
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchStart(uint8_t tag);
-      static bool onTouchEnd(uint8_t tag);
-      static void onIdle();
-  };
-
-#endif // FTDI_INTERFACE_SOUNDS_SCREEN
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchStart(uint8_t tag);
+    static bool onTouchEnd(uint8_t tag);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/jerk_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/jerk_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_JERK_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_JERK_SCREEN
 #define FTDI_JERK_SCREEN_CLASS JerkScreen
 
-  class JerkScreen : public BaseNumericAdjustmentScreen, public CachedScreen<JERK_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_JERK_SCREEN
+class JerkScreen : public BaseNumericAdjustmentScreen, public CachedScreen<JERK_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/junction_deviation_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/junction_deviation_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_JUNCTION_DEVIATION_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_JUNCTION_DEVIATION_SCREEN
 #define FTDI_JUNCTION_DEVIATION_SCREEN_CLASS JunctionDeviationScreen
 
-  class JunctionDeviationScreen : public BaseNumericAdjustmentScreen, public CachedScreen<JUNC_DEV_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_JUNCTION_DEVIATION_SCREEN
+class JunctionDeviationScreen : public BaseNumericAdjustmentScreen, public CachedScreen<JUNC_DEV_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/kill_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/kill_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_KILL_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_KILL_SCREEN
 #define FTDI_KILL_SCREEN_CLASS KillScreen
 
@@ -30,5 +31,3 @@ class KillScreen {
   public:
     static void show(const char*);
 };
-
-#endif // FTDI_KILL_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/language_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/language_menu.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_LANGUAGE_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_LANGUAGE_MENU
 #define FTDI_LANGUAGE_MENU_CLASS LanguageMenu
 
-  class LanguageMenu : public BaseScreen, public UncachedScreen {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_LANGUAGE_MENU
+class LanguageMenu : public BaseScreen, public UncachedScreen {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/leveling_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/leveling_menu.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_LEVELING_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_LEVELING_MENU
 #define FTDI_LEVELING_MENU_CLASS LevelingMenu
 
-  class LevelingMenu : public BaseScreen, public CachedScreen<LEVELING_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_LEVELING_MENU
+class LevelingMenu : public BaseScreen, public CachedScreen<LEVELING_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/linear_advance_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/linear_advance_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_LINEAR_ADVANCE_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_LINEAR_ADVANCE_SCREEN
 #define FTDI_LINEAR_ADVANCE_SCREEN_CLASS LinearAdvanceScreen
 
-  class LinearAdvanceScreen : public BaseNumericAdjustmentScreen, public CachedScreen<LINEAR_ADVANCE_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_LINEAR_ADVANCE_SCREEN
+class LinearAdvanceScreen : public BaseNumericAdjustmentScreen, public CachedScreen<LINEAR_ADVANCE_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/lock_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/lock_screen.h
@@ -20,35 +20,34 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_LOCK_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_LOCK_SCREEN
 #define FTDI_LOCK_SCREEN_CLASS LockScreen
 
-  struct LockScreenData {
-    char passcode[5];
-  };
+struct LockScreenData {
+  char passcode[5];
+};
 
-  class LockScreen : public BaseScreen, public CachedScreen<LOCK_SCREEN_CACHE> {
-    private:
-      friend InterfaceSettingsScreen;
+class LockScreen : public BaseScreen, public CachedScreen<LOCK_SCREEN_CACHE> {
+  private:
+    friend InterfaceSettingsScreen;
 
-      static uint16_t passcode;
+    static uint16_t passcode;
 
-      static char & message_style();
-      static uint16_t compute_checksum();
-      static void onPasscodeEntered();
-    public:
-      static bool is_enabled();
-      static void check_passcode();
-      static void enable();
-      static void disable();
+    static char & message_style();
+    static uint16_t compute_checksum();
+    static void onPasscodeEntered();
+  public:
+    static bool is_enabled();
+    static void check_passcode();
+    static void enable();
+    static void disable();
 
-      static void set_hash(uint16_t pass) {passcode = pass;};
-      static uint16_t get_hash() {return passcode;};
+    static void set_hash(uint16_t pass) {passcode = pass;};
+    static uint16_t get_hash() {return passcode;};
 
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_LOCK_SCREEN
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/main_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/main_menu.h
@@ -21,7 +21,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_MAIN_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_MAIN_MENU
 #define FTDI_MAIN_MENU_CLASS MainMenu
 
@@ -30,5 +31,3 @@ class MainMenu : public BaseScreen, public CachedScreen<MENU_SCREEN_CACHE> {
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_MAIN_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/max_acceleration_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/max_acceleration_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_MAX_ACCELERATION_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_MAX_ACCELERATION_SCREEN
 #define FTDI_MAX_ACCELERATION_SCREEN_CLASS MaxAccelerationScreen
 
-  class MaxAccelerationScreen : public BaseNumericAdjustmentScreen, public CachedScreen<MAX_ACCELERATION_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_MAX_ACCELERATION_SCREEN
+class MaxAccelerationScreen : public BaseNumericAdjustmentScreen, public CachedScreen<MAX_ACCELERATION_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/max_velocity_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/max_velocity_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_MAX_VELOCITY_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_MAX_VELOCITY_SCREEN
 #define FTDI_MAX_VELOCITY_SCREEN_CLASS MaxVelocityScreen
 
-  class MaxVelocityScreen : public BaseNumericAdjustmentScreen, public CachedScreen<MAX_VELOCITY_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_MAX_VELOCITY_SCREEN
+class MaxVelocityScreen : public BaseNumericAdjustmentScreen, public CachedScreen<MAX_VELOCITY_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/media_player_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/media_player_screen.h
@@ -20,22 +20,21 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_MEDIA_PLAYER_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_MEDIA_PLAYER_SCREEN
 #define FTDI_MEDIA_PLAYER_SCREEN_CLASS MediaPlayerScreen
 
-  class MediaPlayerScreen : public BaseScreen, public UncachedScreen {
-    private:
-      typedef int16_t media_streamer_func_t(void *obj, void *buff, size_t bytes);
+class MediaPlayerScreen : public BaseScreen, public UncachedScreen {
+  private:
+    typedef int16_t media_streamer_func_t(void *obj, void *buff, size_t bytes);
 
-    public:
-      static bool playCardMedia();
-      static bool playBootMedia();
+  public:
+    static bool playCardMedia();
+    static bool playBootMedia();
 
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
 
-      static void playStream(void *obj, media_streamer_func_t*);
-  };
-
-#endif // FTDI_MEDIA_PLAYER_SCREEN
+    static void playStream(void *obj, media_streamer_func_t*);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/move_axis_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/move_axis_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_MOVE_AXIS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_MOVE_AXIS_SCREEN
 #define FTDI_MOVE_AXIS_SCREEN_CLASS MoveAxisScreen
 
@@ -45,5 +46,3 @@ class MoveAxisScreen : public BaseMoveAxisScreen, public CachedScreen<MOVE_AXIS_
     static void onRedraw(draw_mode_t);
     static void onIdle();
 };
-
-#endif // FTDI_MOVE_AXIS_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/nozzle_offsets_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/nozzle_offsets_screen.h
@@ -20,15 +20,14 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_NOZZLE_OFFSETS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_NOZZLE_OFFSETS_SCREEN
 #define FTDI_NOZZLE_OFFSETS_SCREEN_CLASS NozzleOffsetScreen
 
-  class NozzleOffsetScreen : public BaseNumericAdjustmentScreen, public CachedScreen<NOZZLE_OFFSET_SCREEN_CACHE> {
-    public:
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_NOZZLE_OFFSETS_SCREEN
+class NozzleOffsetScreen : public BaseNumericAdjustmentScreen, public CachedScreen<NOZZLE_OFFSET_SCREEN_CACHE> {
+  public:
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/nudge_nozzle_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/nudge_nozzle_screen.h
@@ -20,26 +20,25 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_NUDGE_NOZZLE_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_NUDGE_NOZZLE_SCREEN
 #define FTDI_NUDGE_NOZZLE_SCREEN_CLASS NudgeNozzleScreen
 
-  struct NudgeNozzleScreenData {
-    struct BaseNumericAdjustmentScreenData placeholder;
-    xyz_int_t rel;
-    #if HAS_MULTI_EXTRUDER
-      bool link_nozzles;
-    #endif
-    bool show_offsets;
-  };
+struct NudgeNozzleScreenData {
+  struct BaseNumericAdjustmentScreenData placeholder;
+  xyz_int_t rel;
+  #if HAS_MULTI_EXTRUDER
+    bool link_nozzles;
+  #endif
+  bool show_offsets;
+};
 
-  class NudgeNozzleScreen : public BaseNumericAdjustmentScreen, public CachedScreen<ADJUST_OFFSETS_SCREEN_CACHE> {
-    public:
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-      static bool onTouchHeld(uint8_t tag);
-      static void onIdle();
-  };
-
-#endif // FTDI_NUDGE_NOZZLE_SCREEN
+class NudgeNozzleScreen : public BaseNumericAdjustmentScreen, public CachedScreen<ADJUST_OFFSETS_SCREEN_CACHE> {
+  public:
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+    static bool onTouchHeld(uint8_t tag);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/restore_failsafe_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/restore_failsafe_dialog_box.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_RESTORE_FAILSAFE_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_RESTORE_FAILSAFE_DIALOG_BOX
 #define FTDI_RESTORE_FAILSAFE_DIALOG_BOX_CLASS RestoreFailsafeDialogBox
 
@@ -29,5 +30,3 @@ class RestoreFailsafeDialogBox : public DialogBoxBaseClass, public UncachedScree
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_RESTORE_FAILSAFE_DIALOG_BOX

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/save_settings_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/save_settings_dialog_box.h
@@ -20,20 +20,19 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_SAVE_SETTINGS_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_SAVE_SETTINGS_DIALOG_BOX
 #define FTDI_SAVE_SETTINGS_DIALOG_BOX_CLASS SaveSettingsDialogBox
 
-  class SaveSettingsDialogBox : public DialogBoxBaseClass, public UncachedScreen {
-    private:
-      static bool needs_save;
+class SaveSettingsDialogBox : public DialogBoxBaseClass, public UncachedScreen {
+  private:
+    static bool needs_save;
 
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
 
-      static void promptToSaveSettings();
-      static void settingsChanged() {needs_save = true;}
-  };
-
-#endif // FTDI_SAVE_SETTINGS_DIALOG_BOX
+    static void promptToSaveSettings();
+    static void settingsChanged() {needs_save = true;}
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/spinner_dialog_box.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/spinner_dialog_box.h
@@ -20,23 +20,22 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_SPINNER_DIALOG_BOX // Don't use pragma once here
+#pragma once
+
 #define FTDI_SPINNER_DIALOG_BOX
 #define FTDI_SPINNER_DIALOG_BOX_CLASS SpinnerDialogBox
 
-  struct SpinnerDialogBoxData {
-    bool auto_hide;
-  };
+struct SpinnerDialogBoxData {
+  bool auto_hide;
+};
 
-  class SpinnerDialogBox : public DialogBoxBaseClass, public CachedScreen<SPINNER_CACHE,SPINNER_DL_SIZE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static void onIdle();
+class SpinnerDialogBox : public DialogBoxBaseClass, public CachedScreen<SPINNER_CACHE,SPINNER_DL_SIZE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static void onIdle();
 
-      static void show(const progmem_str);
-      static void hide();
-      static void enqueueAndWait_P(const progmem_str commands);
-      static void enqueueAndWait_P(const progmem_str message, const progmem_str commands);
-  };
-
-#endif // FTDI_SPINNER_DIALOG_BOX
+    static void show(const progmem_str);
+    static void hide();
+    static void enqueueAndWait_P(const progmem_str commands);
+    static void enqueueAndWait_P(const progmem_str message, const progmem_str commands);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/statistics_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/statistics_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_STATISTICS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_STATISTICS_SCREEN
 #define FTDI_STATISTICS_SCREEN_CLASS StatisticsScreen
 
-  class StatisticsScreen : public BaseScreen, public UncachedScreen {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-  };
-
-#endif // FTDI_STATISTICS_SCREEN
+class StatisticsScreen : public BaseScreen, public UncachedScreen {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/status_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/status_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_STATUS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_STATUS_SCREEN
 #define FTDI_STATUS_SCREEN_CLASS StatusScreen
 
@@ -42,5 +43,3 @@ class StatusScreen : public BaseScreen, public CachedScreen<STATUS_SCREEN_CACHE,
     static void onIdle();
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_STATUS_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stepper_bump_sensitivity_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stepper_bump_sensitivity_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_STEPPER_BUMP_SENSITIVITY_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_STEPPER_BUMP_SENSITIVITY_SCREEN
 #define FTDI_STEPPER_BUMP_SENSITIVITY_SCREEN_CLASS StepperBumpSensitivityScreen
 
-  class StepperBumpSensitivityScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEPPER_BUMP_SENSITIVITY_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_STEPPER_BUMP_SENSITIVITY_SCREEN
+class StepperBumpSensitivityScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEPPER_BUMP_SENSITIVITY_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stepper_current_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stepper_current_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_STEPPER_CURRENT_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_STEPPER_CURRENT_SCREEN
 #define FTDI_STEPPER_CURRENT_SCREEN_CLASS StepperCurrentScreen
 
-  class StepperCurrentScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEPPER_CURRENT_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_STEPPER_CURRENT_SCREEN
+class StepperCurrentScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEPPER_CURRENT_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/steps_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/steps_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_STEPS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_STEPS_SCREEN
 #define FTDI_STEPS_SCREEN_CLASS StepsScreen
 
@@ -29,5 +30,3 @@ class StepsScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEP
     static void onRedraw(draw_mode_t);
     static bool onTouchHeld(uint8_t tag);
 };
-
-#endif // FTDI_STEPS_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stress_test_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stress_test_screen.h
@@ -20,30 +20,29 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_STRESS_TEST_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_STRESS_TEST_SCREEN
 #define FTDI_STRESS_TEST_SCREEN_CLASS StressTestScreen
 
-  struct StressTestScreenData {
-    uint32_t next_watchdog_trigger;
-    const char*  message;
-  };
+struct StressTestScreenData {
+  uint32_t next_watchdog_trigger;
+  const char*  message;
+};
 
-  class StressTestScreen : public BaseScreen, public UncachedScreen {
-    private:
-      static void drawDots(uint16_t x, uint16_t y, uint16_t h, uint16_t v);
-      static bool watchDogTestNow();
-      static void recursiveLockup();
-      static void iterativeLockup();
-      static void runTestOnBootup(bool enable);
+class StressTestScreen : public BaseScreen, public UncachedScreen {
+  private:
+    static void drawDots(uint16_t x, uint16_t y, uint16_t h, uint16_t v);
+    static bool watchDogTestNow();
+    static void recursiveLockup();
+    static void iterativeLockup();
+    static void runTestOnBootup(bool enable);
 
-    public:
-      static void startupCheck();
+  public:
+    static void startupCheck();
 
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchEnd(uint8_t tag);
-      static void onIdle();
-  };
-
-#endif // FTDI_STRESS_TEST_SCREEN
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchEnd(uint8_t tag);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/temperature_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/temperature_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_TEMPERATURE_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_TEMPERATURE_SCREEN
 #define FTDI_TEMPERATURE_SCREEN_CLASS TemperatureScreen
 
-  class TemperatureScreen : public BaseNumericAdjustmentScreen, public CachedScreen<TEMPERATURE_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_TEMPERATURE_SCREEN
+class TemperatureScreen : public BaseNumericAdjustmentScreen, public CachedScreen<TEMPERATURE_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/touch_calibration_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/touch_calibration_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_TOUCH_CALIBRATION_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_TOUCH_CALIBRATION_SCREEN
 #define FTDI_TOUCH_CALIBRATION_SCREEN_CLASS TouchCalibrationScreen
 
@@ -31,5 +32,3 @@ class TouchCalibrationScreen : public BaseScreen, public UncachedScreen {
     static void onRedraw(draw_mode_t);
     static void onIdle();
 };
-
-#endif // FTDI_TOUCH_CALIBRATION_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/touch_registers_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/touch_registers_screen.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_TOUCH_REGISTERS_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_TOUCH_REGISTERS_SCREEN
 #define FTDI_TOUCH_REGISTERS_SCREEN_CLASS TouchRegistersScreen
 
@@ -29,5 +30,3 @@ class TouchRegistersScreen : public BaseScreen, public UncachedScreen {
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_TOUCH_REGISTERS_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/tune_menu.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/tune_menu.h
@@ -20,7 +20,8 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_TUNE_MENU // Don't use pragma once here
+#pragma once
+
 #define FTDI_TUNE_MENU
 #define FTDI_TUNE_MENU_CLASS TuneMenu
 
@@ -32,5 +33,3 @@ class TuneMenu : public BaseScreen, public CachedScreen<TUNE_SCREEN_CACHE> {
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#endif // FTDI_TUNE_MENU

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/widget_demo_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/widget_demo_screen.h
@@ -20,16 +20,15 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_WIDGET_DEMO_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_WIDGET_DEMO_SCREEN
 #define FTDI_WIDGET_DEMO_SCREEN_CLASS WidgetsScreen
 
-  class WidgetsScreen : public BaseScreen, public UncachedScreen {
-    public:
-      static void onEntry();
-      static void onRedraw(draw_mode_t);
-      static bool onTouchStart(uint8_t tag);
-      static void onIdle();
-  };
-
-#endif // FTDI_WIDGET_DEMO_SCREEN
+class WidgetsScreen : public BaseScreen, public UncachedScreen {
+  public:
+    static void onEntry();
+    static void onRedraw(draw_mode_t);
+    static bool onTouchStart(uint8_t tag);
+    static void onIdle();
+};

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/z_offset_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/z_offset_screen.h
@@ -20,14 +20,13 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#ifndef FTDI_Z_OFFSET_SCREEN // Don't use pragma once here
+#pragma once
+
 #define FTDI_Z_OFFSET_SCREEN
 #define FTDI_Z_OFFSET_SCREEN_CLASS ZOffsetScreen
 
-  class ZOffsetScreen : public BaseNumericAdjustmentScreen, public CachedScreen<ZOFFSET_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-
-#endif // FTDI_Z_OFFSET_SCREEN
+class ZOffsetScreen : public BaseNumericAdjustmentScreen, public CachedScreen<ZOFFSET_SCREEN_CACHE> {
+  public:
+    static void onRedraw(draw_mode_t);
+    static bool onTouchHeld(uint8_t tag);
+};


### PR DESCRIPTION
This change makes the sub-headers of `screen.h` a little cleaner.
- Replace c-style header wrappers with `#pragma once`
- Left-justify header code
